### PR TITLE
Framework compatibility

### DIFF
--- a/UIFont+OpenSans.m
+++ b/UIFont+OpenSans.m
@@ -5,13 +5,18 @@
 //
 
 #import <CoreText/CoreText.h>
-#import "UIFont+OpenSans.h"
+#import <OpenSans/UIFont+OpenSans.h>
 
+@interface KOSFontLoader : NSObject
 
-@implementation UIFont (OpenSans)
++ (void)loadFontWithName:(NSString *)fontName;
 
-void KOSLoadFontWithName(NSString *fontName) {
-    NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"OpenSans" withExtension:@"bundle"];
+@end
+
+@implementation KOSFontLoader
+
++ (void)loadFontWithName:(NSString *)fontName {
+    NSURL *bundleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"OpenSans" withExtension:@"bundle"];
     NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
     NSURL *fontURL = [bundle URLForResource:fontName withExtension:@"ttf"];
     NSData *fontData = [NSData dataWithContentsOfURL:fontURL];
@@ -25,16 +30,20 @@ void KOSLoadFontWithName(NSString *fontName) {
             CFStringRef errorDescription = CFErrorCopyDescription(error);
             @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:(__bridge NSString *)errorDescription userInfo:@{ NSUnderlyingErrorKey: (__bridge NSError *)error }];
         }
-
+        
         CFRelease(font);
     }
 
     CFRelease(provider);
 }
 
+@end
+
+@implementation UIFont (OpenSans)
+
 + (instancetype)kosLoadAndReturnFont:(NSString *)fontName size:(CGFloat)fontSize onceToken:(dispatch_once_t *)onceToken fontFileName:(NSString *)fontFileName {
     dispatch_once(onceToken, ^{
-        KOSLoadFontWithName(fontFileName);
+        [KOSFontLoader loadFontWithName:fontFileName];
     });
 
     return [self fontWithName:fontName size:fontSize];
@@ -91,4 +100,3 @@ void KOSLoadFontWithName(NSString *fontName) {
 }
 
 @end
-


### PR DESCRIPTION
OpenSans now works when it becomes a framework with CocoaPods 0.36.

Two steps were necessary (based on [this CocoaPods blog post](http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/)):
- Used a system import (`<OpenSans/UIFont+OpenSans.h>`) to import the header.
- Created a private class to load the font, as `NSBundle +mainBundle` needs to be replaced with `NSBundle +bundleForClass:`, but couldn't do it from a category.